### PR TITLE
chore: refactor color logic in multiple components

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <header>
-  <app-navbar [navbarColors]="getPaletteColors() | async"></app-navbar>
+  <app-navbar [navbarColors]="getAppColors() | async"></app-navbar>
 </header>
 <div class="router-content" *ngIf="!loading">
     <router-outlet></router-outlet>
@@ -7,7 +7,7 @@
 <div *ngIf="loading" class="main-container">
     <app-loading-spinner></app-loading-spinner>
 </div>
-<app-footer [color]="(getPaletteColors() | async).background" *ngIf="!loading"></app-footer>
+<app-footer [color]="(getAppColors() | async).background" *ngIf="!loading"></app-footer>
 
 
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <header>
-  <app-navbar [navbarColors]="getNavbarColor() | async"></app-navbar>
+  <app-navbar [navbarColors]="getPaletteColors() | async"></app-navbar>
 </header>
 <div class="router-content" *ngIf="!loading">
     <router-outlet></router-outlet>
@@ -7,7 +7,7 @@
 <div *ngIf="loading" class="main-container">
     <app-loading-spinner></app-loading-spinner>
 </div>
-<app-footer [color]="(getNavbarColor() | async).background" *ngIf="!loading"></app-footer>
+<app-footer [color]="(getPaletteColors() | async).background" *ngIf="!loading"></app-footer>
 
 
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -41,8 +41,8 @@ export class AppComponent implements OnInit {
 
     title = 'ITBA-IEEE-Website-A9';
 
-    getPaletteColors() {
-        return this.appConfigService.getPaletteColors();
+    getAppColors() {
+        return this.appConfigService.getAppColors();
     }
 
     useLanguage(language: string) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -32,17 +32,17 @@ export class AppComponent implements OnInit {
         this.router.events.subscribe(event => {
             if (event instanceof GuardsCheckStart) {
                 this.loading = true;
-            }     
+            }
             if (event instanceof GuardsCheckEnd || event instanceof NavigationCancel) {
                 this.loading = false;
-            } 
+            }
         });
     }
 
     title = 'ITBA-IEEE-Website-A9';
 
-    getNavbarColor() {
-        return this.appConfigService.getNavbarColor();
+    getPaletteColors() {
+        return this.appConfigService.getPaletteColors();
     }
 
     useLanguage(language: string) {

--- a/src/app/core/services/configuration/app-config.service.ts
+++ b/src/app/core/services/configuration/app-config.service.ts
@@ -5,7 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 import {NavigationEnd, Router} from '@angular/router';
 
 
-export interface PaletteColors {
+export interface AppColors {
   background: string;
   underlying: string;
   hover: string;
@@ -16,7 +16,7 @@ export interface PaletteColors {
     providedIn: 'root'
 })
 export class AppConfigService {
-  private paletteColorsSource = new BehaviorSubject<PaletteColors>({
+  private appColorsSource = new BehaviorSubject<AppColors>({
     background: '#00629BFF', // default background color
     underlying: '#00B5E2FF', // default underlying color
     hover: '#3381AFFF'            // default hover color
@@ -25,7 +25,7 @@ export class AppConfigService {
   constructor(private titleService: Title, private translate: TranslateService, private router: Router) {
     router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(() => {
       this.resetTitle();
-      this.resetPaletteColors();
+      this.resetAppColors();
     });
   }
 
@@ -43,19 +43,19 @@ export class AppConfigService {
     }
 
   // Tiene que ser de tipo RGB, RGBA o HEX en formato CSS
-  setPaletteColors(colors: PaletteColors) {
-    this.paletteColorsSource.next(colors);
+  setAppColors(colors: AppColors) {
+    this.appColorsSource.next(colors);
   }
 
-  resetPaletteColors() {
-    this.paletteColorsSource.next({
+  resetAppColors() {
+    this.appColorsSource.next({
       background: '#00629BFF',
       underlying: '#00B5E2FF',
       hover: '#3381AFFF'
     });
   }
 
-  getPaletteColors() {
-    return this.paletteColorsSource.asObservable();
+  getAppColors() {
+    return this.appColorsSource.asObservable();
   }
 }

--- a/src/app/core/services/configuration/app-config.service.ts
+++ b/src/app/core/services/configuration/app-config.service.ts
@@ -5,7 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 import {NavigationEnd, Router} from '@angular/router';
 
 
-export interface NavbarColors {
+export interface PaletteColors {
   background: string;
   underlying: string;
   hover: string;
@@ -16,7 +16,7 @@ export interface NavbarColors {
     providedIn: 'root'
 })
 export class AppConfigService {
-  private navbarColorsSource = new BehaviorSubject<NavbarColors>({
+  private paletteColorsSource = new BehaviorSubject<PaletteColors>({
     background: '#00629BFF', // default background color
     underlying: '#00B5E2FF', // default underlying color
     hover: '#3381AFFF'            // default hover color
@@ -25,7 +25,7 @@ export class AppConfigService {
   constructor(private titleService: Title, private translate: TranslateService, private router: Router) {
     router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(() => {
       this.resetTitle();
-      this.resetNavbarColor();
+      this.resetPaletteColors();
     });
   }
 
@@ -43,19 +43,19 @@ export class AppConfigService {
     }
 
   // Tiene que ser de tipo RGB, RGBA o HEX en formato CSS
-  setNavbarColor(colors: NavbarColors) {
-    this.navbarColorsSource.next(colors);
+  setPaletteColors(colors: PaletteColors) {
+    this.paletteColorsSource.next(colors);
   }
 
-  resetNavbarColor() {
-    this.navbarColorsSource.next({
+  resetPaletteColors() {
+    this.paletteColorsSource.next({
       background: '#00629BFF',
       underlying: '#00B5E2FF',
       hover: '#3381AFFF'
     });
   }
 
-  getNavbarColor() {
-    return this.navbarColorsSource.asObservable();
+  getPaletteColors() {
+    return this.paletteColorsSource.asObservable();
   }
 }

--- a/src/app/modules/asimov-cup/pages/asimov-cup/asimov-cup.component.ts
+++ b/src/app/modules/asimov-cup/pages/asimov-cup/asimov-cup.component.ts
@@ -97,7 +97,7 @@ export class AsimovCupComponent implements OnInit {
     ngOnInit(): void {
         this.getAsimovCupEvent();
         // Set navbar color
-        this.appConfigService.setNavbarColor({
+        this.appConfigService.setPaletteColors({
             background: '#862633',
             underlying: '#C83D59FF',
             hover: '#9E4C67FF'

--- a/src/app/modules/asimov-cup/pages/asimov-cup/asimov-cup.component.ts
+++ b/src/app/modules/asimov-cup/pages/asimov-cup/asimov-cup.component.ts
@@ -97,7 +97,7 @@ export class AsimovCupComponent implements OnInit {
     ngOnInit(): void {
         this.getAsimovCupEvent();
         // Set navbar color
-        this.appConfigService.setPaletteColors({
+        this.appConfigService.setAppColors({
             background: '#862633',
             underlying: '#C83D59FF',
             hover: '#9E4C67FF'

--- a/src/app/modules/ras/pages/ras/ras.component.html
+++ b/src/app/modules/ras/pages/ras/ras.component.html
@@ -22,7 +22,7 @@
       </ul>
     </div>
     <ng-template #loadingEventsBlock>
-      <app-loading-spinner [isRas]="true"></app-loading-spinner>
+      <app-loading-spinner></app-loading-spinner>
     </ng-template>
     <hr>
     <div class="text-container">

--- a/src/app/modules/ras/pages/ras/ras.component.ts
+++ b/src/app/modules/ras/pages/ras/ras.component.ts
@@ -23,7 +23,7 @@ export class RasComponent implements OnInit {
     ngOnInit(): void {
         this.getRasEvents();
         this.team$ = this.teamService.getRasTeam();
-        this.appConfigService.setPaletteColors({
+        this.appConfigService.setAppColors({
             background: '#862633',
             underlying: '#C83D59FF',
             hover: '#9E4C67FF'

--- a/src/app/modules/ras/pages/ras/ras.component.ts
+++ b/src/app/modules/ras/pages/ras/ras.component.ts
@@ -23,7 +23,7 @@ export class RasComponent implements OnInit {
     ngOnInit(): void {
         this.getRasEvents();
         this.team$ = this.teamService.getRasTeam();
-        this.appConfigService.setNavbarColor({
+        this.appConfigService.setPaletteColors({
             background: '#862633',
             underlying: '#C83D59FF',
             hover: '#9E4C67FF'

--- a/src/app/modules/wie/pages/wie.component.ts
+++ b/src/app/modules/wie/pages/wie.component.ts
@@ -11,7 +11,7 @@ export class WieComponent implements OnInit {
     constructor(private appConfigService: AppConfigService) { }
 
     ngOnInit(): void {
-        this.appConfigService.setPaletteColors({
+        this.appConfigService.setAppColors({
             background: '#702f8a',
             underlying: '#92519CFF',
             hover: '#AD7CB5FF'

--- a/src/app/modules/wie/pages/wie.component.ts
+++ b/src/app/modules/wie/pages/wie.component.ts
@@ -11,7 +11,7 @@ export class WieComponent implements OnInit {
     constructor(private appConfigService: AppConfigService) { }
 
     ngOnInit(): void {
-        this.appConfigService.setNavbarColor({
+        this.appConfigService.setPaletteColors({
             background: '#702f8a',
             underlying: '#92519CFF',
             hover: '#AD7CB5FF'

--- a/src/app/shared/components/event-editor-modal/event-editor-modal.component.css
+++ b/src/app/shared/components/event-editor-modal/event-editor-modal.component.css
@@ -44,22 +44,22 @@
 
 .modal-footer .close-btn {
     background-color: var(--bs-light);
-    color: var(--bs-ieee-bright-blue);
-    border-color: var(--bs-ieee-bright-blue);
-    box-shadow: 0 0 4px var(--bs-ieee-bright-blue);
+    color: var(--color);
+    border-color: var(--color);
+    box-shadow: 0 0 4px var(--color);
 }
 
 .modal-footer .close-btn:hover {
-    box-shadow: 0 0 2px var(--bs-ieee-bright-blue);
+    box-shadow: 0 0 2px var(--color);
 }
 
 .modal-footer .save-btn {
-    background-color: var(--bs-ieee-bright-blue);
+    background-color: var(--color);
     color: var(--bs-light);
-    border-color: var(--bs-ieee-bright-blue);
-    box-shadow: 0 0 4px var(--bs-ieee-bright-blue);
+    border-color: var(--color);
+    box-shadow: 0 0 4px var(--color);
 }
 
 .modal-footer .save-btn:hover {
-    box-shadow: 0 0 2px var(--bs-ieee-bright-blue);
+    box-shadow: 0 0 2px var(--color);
 }

--- a/src/app/shared/components/event-editor-modal/event-editor-modal.component.html
+++ b/src/app/shared/components/event-editor-modal/event-editor-modal.component.html
@@ -36,7 +36,7 @@
             </p>
         </div>
     </div>
-    <div class="modal-footer" [style.--color]="color">
+    <div class="modal-footer" [style.--color]="(getAppColors() | async).background">
         <button type="button" class="btn close-btn" (click)="modalRef.hide()">{{ "HOME.EVENTS.EDIT.CANCEL" | translate }}</button>
         <button type="submit" class="btn save-btn" [disabled]="eventForm.invalid || loading">
             {{ "HOME.EVENTS.EDIT.UPDATE" | translate }}

--- a/src/app/shared/components/event-editor-modal/event-editor-modal.component.html
+++ b/src/app/shared/components/event-editor-modal/event-editor-modal.component.html
@@ -36,7 +36,7 @@
             </p>
         </div>
     </div>
-    <div class="modal-footer">
+    <div class="modal-footer" [style.--color]="color">
         <button type="button" class="btn close-btn" (click)="modalRef.hide()">{{ "HOME.EVENTS.EDIT.CANCEL" | translate }}</button>
         <button type="submit" class="btn save-btn" [disabled]="eventForm.invalid || loading">
             {{ "HOME.EVENTS.EDIT.UPDATE" | translate }}

--- a/src/app/shared/components/event-editor-modal/event-editor-modal.component.ts
+++ b/src/app/shared/components/event-editor-modal/event-editor-modal.component.ts
@@ -47,9 +47,9 @@ export class EventEditorModalComponent implements OnInit {
     }
 
     getColor() {
-        this.appConfigService.getPaletteColors().subscribe(
-            palletColors => {
-                this.color = palletColors.background;
+        this.appConfigService.getAppColors().subscribe(
+            appColors => {
+                this.color = appColors.background;
             }
         );
     }

--- a/src/app/shared/components/event-editor-modal/event-editor-modal.component.ts
+++ b/src/app/shared/components/event-editor-modal/event-editor-modal.component.ts
@@ -10,6 +10,7 @@ import {
     ValidatorFn,
     Validators
 } from "@angular/forms";
+import {AppConfigService} from "../../../core/services/configuration/app-config.service";
 
 @Component({
     selector: 'app-event-editor-modal',
@@ -22,8 +23,9 @@ export class EventEditorModalComponent implements OnInit {
     eventForm: FormGroup;
     errorI18n: string = null;
     loading = false;
+    color: string;
 
-    constructor(private eventService: EventService, public modalRef: MDBModalRef) { }
+    constructor(private eventService: EventService, public modalRef: MDBModalRef, private appConfigService: AppConfigService) { }
 
     private getIsoDate(date: Date): string {
         return date.toISOString().split('T')[0];
@@ -44,6 +46,14 @@ export class EventEditorModalComponent implements OnInit {
         }
     }
 
+    getColor() {
+        this.appConfigService.getPaletteColors().subscribe(
+            palletColors => {
+                this.color = palletColors.background;
+            }
+        );
+    }
+
     ngOnInit(): void {
         const initialDate = (this.event.dates && this.event.dates.length > 0) ?
             this.getIsoDate(this.event.dates[0].date) :
@@ -55,6 +65,7 @@ export class EventEditorModalComponent implements OnInit {
                 this.nonPastDateValidator()
             ])
         });
+        this.getColor();
     }
 
     get date() {

--- a/src/app/shared/components/event-editor-modal/event-editor-modal.component.ts
+++ b/src/app/shared/components/event-editor-modal/event-editor-modal.component.ts
@@ -23,7 +23,6 @@ export class EventEditorModalComponent implements OnInit {
     eventForm: FormGroup;
     errorI18n: string = null;
     loading = false;
-    color: string;
 
     constructor(private eventService: EventService, public modalRef: MDBModalRef, private appConfigService: AppConfigService) { }
 
@@ -46,12 +45,8 @@ export class EventEditorModalComponent implements OnInit {
         }
     }
 
-    getColor() {
-        this.appConfigService.getAppColors().subscribe(
-            appColors => {
-                this.color = appColors.background;
-            }
-        );
+    getAppColors() {
+        return this.appConfigService.getAppColors();
     }
 
     ngOnInit(): void {
@@ -65,7 +60,6 @@ export class EventEditorModalComponent implements OnInit {
                 this.nonPastDateValidator()
             ])
         });
-        this.getColor();
     }
 
     get date() {

--- a/src/app/shared/components/floating-button/floating-button.component.css
+++ b/src/app/shared/components/floating-button/floating-button.component.css
@@ -13,7 +13,7 @@
 
 .button-tooltip {
     text-wrap: nowrap;
-    background-color: var(--bs-ieee-bright-blue);
+    background-color: var(--color);
     color: var(--bs-light);
     padding: 0.5rem 1rem;
     border-radius: 12px;
@@ -21,7 +21,7 @@
     font-size: 1rem;
     opacity: 100%;
     transition: opacity 0.5s ease;
-    box-shadow: 0 0 4px var(--bs-ieee-bright-blue);
+    box-shadow: 0 0 4px var(--color);
 }
 
 .button-tooltip.hidden {
@@ -31,9 +31,9 @@
 .edit-button {
     font-weight: 600;
     padding: 1rem;
-    border: solid var(--bs-ieee-bright-blue);
+    border: solid var(--color);
     border-radius: 50%;
-    background-color: var(--bs-ieee-bright-blue);
+    background-color: var(--color);
     color: var(--bs-light);
-    box-shadow: 0 0 4px var(--bs-ieee-bright-blue);
+    box-shadow: 0 0 4px var(--color);
 }

--- a/src/app/shared/components/floating-button/floating-button.component.html
+++ b/src/app/shared/components/floating-button/floating-button.component.html
@@ -1,5 +1,5 @@
 <div class="outside-div">
-    <div class="inside-div">
+    <div class="inside-div" [style.--color]="color">
         <span class="button-tooltip" [class.hidden]="!showTooltip">
             {{ tooltipI18n | translate }}
         </span>

--- a/src/app/shared/components/floating-button/floating-button.component.html
+++ b/src/app/shared/components/floating-button/floating-button.component.html
@@ -1,5 +1,5 @@
 <div class="outside-div">
-    <div class="inside-div" [style.--color]="color">
+    <div class="inside-div" [style.--color]="(getAppColors() | async).background">
         <span class="button-tooltip" [class.hidden]="!showTooltip">
             {{ tooltipI18n | translate }}
         </span>

--- a/src/app/shared/components/floating-button/floating-button.component.ts
+++ b/src/app/shared/components/floating-button/floating-button.component.ts
@@ -6,15 +6,18 @@ import {AppConfigService} from "../../../core/services/configuration/app-config.
     templateUrl: './floating-button.component.html',
     styleUrls: ['./floating-button.component.css']
 })
-export class FloatingButtonComponent implements OnInit {
+export class FloatingButtonComponent {
 
     @Input() tooltipI18n: string;
     showTooltip = false;
-    color: string;
 
     @Output() clickEvent = new EventEmitter<void>();
 
     constructor(private appConfigService: AppConfigService) {
+    }
+
+    getAppColors() {
+        return this.appConfigService.getAppColors();
     }
 
     toggleTooltip() {
@@ -23,17 +26,5 @@ export class FloatingButtonComponent implements OnInit {
 
     onClick() {
         this.clickEvent.emit();
-    }
-
-    getColor() {
-        this.appConfigService.getAppColors().subscribe(
-            appColors => {
-                this.color = appColors.background;
-            }
-        );
-    }
-
-    ngOnInit(): void {
-        this.getColor();
     }
 }

--- a/src/app/shared/components/floating-button/floating-button.component.ts
+++ b/src/app/shared/components/floating-button/floating-button.component.ts
@@ -1,16 +1,21 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {AppConfigService} from "../../../core/services/configuration/app-config.service";
 
 @Component({
     selector: 'app-floating-button',
     templateUrl: './floating-button.component.html',
     styleUrls: ['./floating-button.component.css']
 })
-export class FloatingButtonComponent {
+export class FloatingButtonComponent implements OnInit {
 
     @Input() tooltipI18n: string;
     showTooltip = false;
+    color: string;
 
     @Output() clickEvent = new EventEmitter<void>();
+
+    constructor(private appConfigService: AppConfigService) {
+    }
 
     toggleTooltip() {
         this.showTooltip = !this.showTooltip;
@@ -18,5 +23,17 @@ export class FloatingButtonComponent {
 
     onClick() {
         this.clickEvent.emit();
+    }
+
+    getColor() {
+        this.appConfigService.getPaletteColors().subscribe(
+            palletColors => {
+                this.color = palletColors.background;
+            }
+        );
+    }
+
+    ngOnInit(): void {
+        this.getColor();
     }
 }

--- a/src/app/shared/components/floating-button/floating-button.component.ts
+++ b/src/app/shared/components/floating-button/floating-button.component.ts
@@ -26,9 +26,9 @@ export class FloatingButtonComponent implements OnInit {
     }
 
     getColor() {
-        this.appConfigService.getPaletteColors().subscribe(
-            palletColors => {
-                this.color = palletColors.background;
+        this.appConfigService.getAppColors().subscribe(
+            appColors => {
+                this.color = appColors.background;
             }
         );
     }

--- a/src/app/shared/components/loading-spinner/loading-spinner.component.css
+++ b/src/app/shared/components/loading-spinner/loading-spinner.component.css
@@ -10,11 +10,6 @@
     position: relative;
     width: 80px;
     height: 80px;
-    --background-color: var(--bs-ieee-bright-blue);
-}
-
-.lds-roller.ras {
-    --background-color: var(--bs-ieee-bright-red);
 }
 
 .lds-roller div {
@@ -29,7 +24,7 @@
     width: 7px;
     height: 7px;
     border-radius: 50%;
-    background: var(--background-color);
+    background: var(--color);
     margin: -4px 0 0 -4px;
 }
 

--- a/src/app/shared/components/loading-spinner/loading-spinner.component.html
+++ b/src/app/shared/components/loading-spinner/loading-spinner.component.html
@@ -1,5 +1,5 @@
 <div class="spinner-container">
-  <div class="lds-roller" [style.--color]="color">
+  <div class="lds-roller" [style.--color]="(getAppColors() | async).background">
     <div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div>
   </div>
 </div>

--- a/src/app/shared/components/loading-spinner/loading-spinner.component.html
+++ b/src/app/shared/components/loading-spinner/loading-spinner.component.html
@@ -1,5 +1,5 @@
 <div class="spinner-container">
-  <div class="lds-roller" [class.ras] = "!!isRas">
+  <div class="lds-roller" [style.--color]="color">
     <div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div>
   </div>
 </div>

--- a/src/app/shared/components/loading-spinner/loading-spinner.component.ts
+++ b/src/app/shared/components/loading-spinner/loading-spinner.component.ts
@@ -6,21 +6,11 @@ import {AppConfigService} from "../../../core/services/configuration/app-config.
     templateUrl: './loading-spinner.component.html',
     styleUrls: ['./loading-spinner.component.css']
 })
-export class LoadingSpinnerComponent implements OnInit {
-
-    color: string;
+export class LoadingSpinnerComponent  {
 
     constructor(private appConfigService: AppConfigService) { }
 
-    getColor() {
-        this.appConfigService.getAppColors().subscribe(
-            appColors => {
-                this.color = appColors.background;
-            }
-        );
-    }
-
-    ngOnInit(): void {
-        this.getColor();
+    getAppColors() {
+        return this.appConfigService.getAppColors();
     }
 }

--- a/src/app/shared/components/loading-spinner/loading-spinner.component.ts
+++ b/src/app/shared/components/loading-spinner/loading-spinner.component.ts
@@ -1,16 +1,26 @@
-import {Component, Input} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
+import {AppConfigService} from "../../../core/services/configuration/app-config.service";
 
 @Component({
     selector: 'app-loading-spinner',
     templateUrl: './loading-spinner.component.html',
     styleUrls: ['./loading-spinner.component.css']
 })
-export class LoadingSpinnerComponent {
+export class LoadingSpinnerComponent implements OnInit {
 
-    @Input() isRas?: boolean = false;
+    color: string;
 
-    constructor() { }
+    constructor(private appConfigService: AppConfigService) { }
 
+    getColor() {
+        this.appConfigService.getPaletteColors().subscribe(
+            palletColors => {
+                this.color = palletColors.background;
+            }
+        );
+    }
 
-
+    ngOnInit(): void {
+        this.getColor();
+    }
 }

--- a/src/app/shared/components/loading-spinner/loading-spinner.component.ts
+++ b/src/app/shared/components/loading-spinner/loading-spinner.component.ts
@@ -13,9 +13,9 @@ export class LoadingSpinnerComponent implements OnInit {
     constructor(private appConfigService: AppConfigService) { }
 
     getColor() {
-        this.appConfigService.getPaletteColors().subscribe(
-            palletColors => {
-                this.color = palletColors.background;
+        this.appConfigService.getAppColors().subscribe(
+            appColors => {
+                this.color = appColors.background;
             }
         );
     }

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -7,7 +7,7 @@ import {PageScrollService} from 'ngx-page-scroll-core';
 import {DOCUMENT} from '@angular/common';
 import {AuthService} from '../../../core/services/authorization/auth.service';
 import {UserService} from '../../../core/services/user/user.service';
-import {NavbarColors} from '../../../core/services/configuration/app-config.service';
+import {PaletteColors} from '../../../core/services/configuration/app-config.service';
 
 @Component({
   selector: 'app-navbar',
@@ -15,7 +15,7 @@ import {NavbarColors} from '../../../core/services/configuration/app-config.serv
   styleUrls: ['./navbar.component.css']
 })
 export class NavbarComponent implements OnInit, AfterViewInit{
-  @Input() navbarColors: NavbarColors;
+  @Input() navbarColors: PaletteColors;
 
   user$ = new BehaviorSubject<IEEEuser | null>(null);
   isJournalist$ = new BehaviorSubject<boolean>(false);

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -7,7 +7,7 @@ import {PageScrollService} from 'ngx-page-scroll-core';
 import {DOCUMENT} from '@angular/common';
 import {AuthService} from '../../../core/services/authorization/auth.service';
 import {UserService} from '../../../core/services/user/user.service';
-import {PaletteColors} from '../../../core/services/configuration/app-config.service';
+import {AppColors} from '../../../core/services/configuration/app-config.service';
 
 @Component({
   selector: 'app-navbar',
@@ -15,7 +15,7 @@ import {PaletteColors} from '../../../core/services/configuration/app-config.ser
   styleUrls: ['./navbar.component.css']
 })
 export class NavbarComponent implements OnInit, AfterViewInit{
-  @Input() navbarColors: PaletteColors;
+  @Input() navbarColors: AppColors;
 
   user$ = new BehaviorSubject<IEEEuser | null>(null);
   isJournalist$ = new BehaviorSubject<boolean>(false);


### PR DESCRIPTION
- `NavbarColors` is renamed to `AppColors`
- Multiple components use the current `AppColors` to render their view with the corresponding theme:
  - `EventEditorModalComponent`
  - `FloatingButtonComponent`
  - `LoadingSpinnerComponent` 