### PR TITLE
Firestore rules & Admin dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Thumbs.db
 .angular/
 dump/
 mock_data/
+firebase-export-*
 
 *.log
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -8,7 +8,7 @@ service cloud.firestore {
 
     function hasRole(role) {
       let roles = {"admin": 1, "writer": 2};
-      return isSignedIn() && roles[role] in get(/databases/$(database)/documents/roles/$(request.auth.token.email)).data.roles;
+      return isSignedIn() && roles[role] == get(/databases/$(database)/documents/sensitive-user-data/$(request.auth.token.email)).data.role;
     }
 
     function isDataOwner() {
@@ -42,7 +42,7 @@ service cloud.firestore {
       allow create: if isSignedIn() && request.resource.data.uID == request.auth.uid;
     }
 
-    match /roles/{document=**} {
+    match /sensitive-user-data/{document=**} {
       allow read, write: if hasRole("admin");
     }
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,16 +2,48 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // This rule allows anyone on the internet to view, edit, and delete
-    // all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // your app will lose access to your Firestore database
-    match /{document=**} {
-      allow read, write;
+    function isSignedIn() {
+      return request.auth.uid != null;
+    }
+
+    function hasRole(role) {
+      let roles = {"admin": 1, "writer": 2};
+      return isSignedIn() && roles[role] in get(/databases/$(database)/documents/roles/$(request.auth.token.email)).data.roles;
+    }
+
+    function isDataOwner() {
+      return resource.data.uID == request.auth.uid;
+    }
+
+    match /blog-entries/{document=**}  {
+      allow read: if resource.data.listed == true || hasRole("writer") || hasRole("admin");
+      allow write: if hasRole("writer") || hasRole("admin");
+    }
+
+    match /events/{document=**} {
+    	allow read;
+      allow write: if hasRole("admin");
+    }
+
+    match /collection-metadata/{document=**}   {
+      allow read;
+      allow write: if hasRole("admin");
+    }
+
+    match /team/{document=**}  {
+      allow read;
+      allow write: if hasRole("admin");
+    }
+
+    match /users/{document=**}  {
+    	allow get, update, delete: if isDataOwner() || hasRole("admin");
+      allow list: if hasRole("admin");
+      // Solo puede crear el objeto usuario si el id del usuario en el body corresponde con el id del usuario en el token
+      allow create: if isSignedIn() && request.resource.data.uID == request.auth.uid;
+    }
+
+    match /roles/{document=**} {
+      allow read, write: if hasRole("admin");
     }
   }
 }

--- a/scripts/migrate-senstitive-user-data.ts
+++ b/scripts/migrate-senstitive-user-data.ts
@@ -1,0 +1,25 @@
+import {applicationDefault, initializeApp } from 'firebase-admin/app';
+import { getFirestore } from "firebase-admin/firestore";
+
+//  export GOOGLE_APPLICATION_CREDENTIALS="/tmp/key.json"
+initializeApp({
+    credential: applicationDefault(),
+});
+
+export async function migrateRoles() {
+    const userCollection = getFirestore().collection("users");
+    const sensitiveDataCollection = getFirestore().collection("sensitive-user-data");
+    let users = (await userCollection.get()).docs;
+    let roleUsers = users.filter((user) => user.data().role && user.data().role != 0);
+    if (roleUsers.length <= 0) return;
+    const batch = getFirestore().batch();
+    roleUsers.forEach(user => {
+        const ref = sensitiveDataCollection.doc(user.data().email);
+        batch.set(ref, {
+            role: user.data().role
+        }, {
+            merge: true
+        });
+    });
+    await batch.commit();
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -167,6 +167,17 @@ const routes: Routes = [
             ),
     },
     {
+        path: 'admin',
+        loadChildren: () =>
+            import('./modules/admin/admin.module').then(
+                (m) => m.AdminModule
+            ),
+        canActivate: [AuthGuardService],
+        data: {
+            expectedRole: [roles.admin],
+        },
+    },
+    {
         path: '**',
         loadChildren: () =>
             import('./modules/error404/error404.module').then(

--- a/src/app/core/services/admin/admin.service.spec.ts
+++ b/src/app/core/services/admin/admin.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AdminService } from './admin.service';
+
+describe('AdminService', () => {
+  let service: AdminService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AdminService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/admin/admin.service.ts
+++ b/src/app/core/services/admin/admin.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { CollectionReference, Firestore, Query, QueryConstraint, collection, endAt, endBefore, getCountFromServer, getDocs, limit, limitToLast, orderBy, query, startAfter, startAt, where } from '@angular/fire/firestore';
+import { CollectionReference, Firestore, Query, QueryConstraint, collection, doc, endBefore, getCountFromServer, getDocs, limit, limitToLast, orderBy, query, startAfter, startAt, where, writeBatch } from '@angular/fire/firestore';
 import { Observable } from 'rxjs';
 import { IEEEuser } from 'src/app/shared/models/ieee-user/ieee-user';
-import { roles } from 'src/app/shared/models/roles/roles.enum';
+import { IEEEUserFilters } from 'src/app/shared/models/ieee-user/ieee-user-filters';
 
 @Injectable({
   providedIn: 'root'
@@ -25,17 +25,20 @@ export class AdminService {
         obs.next(snap.data().count);
       }).catch(err => {
         obs.error(err);
-      }).finally(obs.complete);
+      }).finally(() => {
+        obs.complete();
+      });
     })
   }
 
-  getTotalCount() {
-    return this.getCount(query(this.collection))
-  }
-
-  getSearchCount(searchword: string) {
-    let end: string = searchword.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1));
-    return this.getCount(query(this.collection, where('email', '>=', searchword), where('email', '<', end)))
+  getTotalCount(filters?: IEEEUserFilters) {
+    let constraints: QueryConstraint[] = [];
+    if (filters?.email) {
+      let end: string = filters.email.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1));
+      constraints.push(where('email', '>=', filters.email), where('email', '<', end));
+    }
+    if (filters?.role) constraints.push(where('role', '==', filters.role));
+    return this.getCount(query(this.collection, ...constraints));
   }
 
   private getUsersPage(query: Query): Observable<IEEEuser[]> {
@@ -51,36 +54,57 @@ export class AdminService {
         obs.next(ans);
       }).catch(err => {
         obs.error(err);
-      }).finally(obs.complete);
+      }).finally(() => {
+        obs.complete();
+      });
     })
   }
 
-  getUsersFirstPage(size: number, searchword?: string): Observable<IEEEuser[]> {
+  getUsersFirstPage(size: number, filters?: IEEEUserFilters): Observable<IEEEuser[]> {
     let constraints: QueryConstraint[] = [limit(size), orderBy("email")];
-    if (searchword) constraints.push(where('email', '>=', searchword), where('email', '<', searchword.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1))));
+    if (filters?.email) constraints.push(where('email', '>=', filters.email), where('email', '<', filters.email.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1))));
+    if (filters?.role) constraints.push(where('role', 'in', filters.role));
     const q = query(this.collection, ...constraints);
     return this.getUsersPage(q);
   }
 
-  getUsersNextPage(last: IEEEuser, size: number, searchword?: string) {
+  getUsersNextPage(last: IEEEuser, size: number, filters?: IEEEUserFilters) {
     let constraints: QueryConstraint[] = [limit(size), orderBy("email"), startAfter(last.email)];
-    if (searchword) constraints.push(where('email', '>=', searchword), where('email', '<', searchword.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1))));
+    if (filters?.email) constraints.push(where('email', '>=', filters.email), where('email', '<', filters.email.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1))));
+    if (filters?.role) constraints.push(where('role', 'in', filters.role));
     const q = query(this.collection, ...constraints);
     return this.getUsersPage(q);
   }
 
-  getUsersPrevPage(first: IEEEuser, size: number, searchword?: string) {
+  getUsersPrevPage(first: IEEEuser, size: number, filters?: IEEEUserFilters) {
     let constraints: QueryConstraint[] = [limitToLast(size), orderBy("email"), endBefore(first.email)];
-    if (searchword) constraints.push(where('email', '>=', searchword), where('email', '<', searchword.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1))));
+    if (filters?.email) constraints.push(where('email', '>=', filters.email), where('email', '<', filters.email.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1))));
+    if (filters?.role) constraints.push(where('role', 'in', filters.role));
     const q = query(this.collection, ...constraints);
     return this.getUsersPage(q);
   }
 
-  addRole(userId: string, role: roles) {
-
+  refreshUserPage(first: IEEEuser, size: number, filters?: IEEEUserFilters) {
+    let constraints: QueryConstraint[] = [limit(size), orderBy("email"), startAt(first.email)];
+    if (filters?.email) constraints.push(where('email', '>=', filters.email), where('email', '<', filters.email.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1))));
+    if (filters?.role) constraints.push(where('role', 'in', filters.role));
+    const q = query(this.collection, ...constraints);
+    return this.getUsersPage(q);
   }
 
-  removeRole(userId: string, role: roles) {
-
+  updateUser(user: IEEEuser, updateRole: boolean): Observable<IEEEuser> {
+    const roleDocument = { role: user.role };
+    return new Observable(obs => {
+      const batch = writeBatch(this.afs);
+      batch.set(doc(this.afs, "users", user.email), user);
+      if (updateRole) batch.set(doc(this.afs, "sensitive-user-data", user.email), roleDocument);
+      batch.commit().then(res => {
+        obs.next(user);
+      }).catch(err => {
+        obs.error(err);
+      }).finally(() => {
+        obs.complete();
+      });
+    })
   }
 }

--- a/src/app/core/services/admin/admin.service.ts
+++ b/src/app/core/services/admin/admin.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@angular/core';
+import { CollectionReference, Firestore, Query, QueryConstraint, collection, endAt, endBefore, getCountFromServer, getDocs, limit, limitToLast, orderBy, query, startAfter, startAt, where } from '@angular/fire/firestore';
+import { Observable } from 'rxjs';
+import { IEEEuser } from 'src/app/shared/models/ieee-user/ieee-user';
+import { roles } from 'src/app/shared/models/roles/roles.enum';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AdminService {
+
+  collectionName: string;
+  collection: CollectionReference;
+
+  constructor(private afs: Firestore) {}
+
+  setCollectionName(collectionName: string) {
+    this.collectionName = collectionName;
+    this.collection = collection(this.afs, collectionName);
+  }
+
+  private getCount(query: Query): Observable<number> {
+    return new Observable<number>(obs => {
+      getCountFromServer(query).then(snap => {
+        obs.next(snap.data().count);
+      }).catch(err => {
+        obs.error(err);
+      }).finally(obs.complete);
+    })
+  }
+
+  getTotalCount() {
+    return this.getCount(query(this.collection))
+  }
+
+  getSearchCount(searchword: string) {
+    let end: string = searchword.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1));
+    return this.getCount(query(this.collection, where('email', '>=', searchword), where('email', '<', end)))
+  }
+
+  private getUsersPage(query: Query): Observable<IEEEuser[]> {
+    return new Observable<IEEEuser[]>(obs => {
+      getDocs(query).then(data => {
+        const ans: IEEEuser[] = [];
+        for (const blogEntry in data.docs) {
+            if (data.docs.hasOwnProperty(blogEntry)) {
+                const doc: IEEEuser = data.docs[blogEntry].data() as IEEEuser;
+                ans.push(doc);
+            }
+        }
+        obs.next(ans);
+      }).catch(err => {
+        obs.error(err);
+      }).finally(obs.complete);
+    })
+  }
+
+  getUsersFirstPage(size: number, searchword?: string): Observable<IEEEuser[]> {
+    let constraints: QueryConstraint[] = [limit(size), orderBy("email")];
+    if (searchword) constraints.push(where('email', '>=', searchword), where('email', '<', searchword.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1))));
+    const q = query(this.collection, ...constraints);
+    return this.getUsersPage(q);
+  }
+
+  getUsersNextPage(last: IEEEuser, size: number, searchword?: string) {
+    let constraints: QueryConstraint[] = [limit(size), orderBy("email"), startAfter(last.email)];
+    if (searchword) constraints.push(where('email', '>=', searchword), where('email', '<', searchword.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1))));
+    const q = query(this.collection, ...constraints);
+    return this.getUsersPage(q);
+  }
+
+  getUsersPrevPage(first: IEEEuser, size: number, searchword?: string) {
+    let constraints: QueryConstraint[] = [limitToLast(size), orderBy("email"), endBefore(first.email)];
+    if (searchword) constraints.push(where('email', '>=', searchword), where('email', '<', searchword.replace(/.$/, c => String.fromCharCode(c.charCodeAt(0) + 1))));
+    const q = query(this.collection, ...constraints);
+    return this.getUsersPage(q);
+  }
+
+  addRole(userId: string, role: roles) {
+
+  }
+
+  removeRole(userId: string, role: roles) {
+
+  }
+}

--- a/src/app/core/services/authorization/auth.service.ts
+++ b/src/app/core/services/authorization/auth.service.ts
@@ -7,7 +7,7 @@ import { Observable, ReplaySubject } from 'rxjs';
 import {createRegularUser} from '../../../shared/models/data-types';
 import {IEEEuser} from '../../../shared/models/ieee-user/ieee-user';
 import { Firestore, doc, getDoc, setDoc } from '@angular/fire/firestore';
-import { Auth, User, UserCredential, createUserWithEmailAndPassword, sendPasswordResetEmail, signInWithEmailAndPassword } from '@angular/fire/auth';
+import { Auth, User, UserCredential, createUserWithEmailAndPassword, onAuthStateChanged, sendPasswordResetEmail, signInWithEmailAndPassword } from '@angular/fire/auth';
 import { roles } from 'src/app/shared/models/roles/roles.enum';
 
 @Injectable({
@@ -25,8 +25,9 @@ export class AuthService {
         this.user = firebaseAuth.currentUser
         // Seteamos observer
         this.accountObs = new ReplaySubject(1);
-        this.firebaseAuth.onAuthStateChanged((usuario) => {
+        onAuthStateChanged(this.firebaseAuth, (usuario) => {
             if (usuario){
+                this.user = usuario;
                 getDoc(doc(this.afs, 'users', usuario.email)).then(data => {
                     const doc = data.data() as IEEEuser;
                     this.account = createRegularUser(doc.fname, doc.lname, doc.email, doc.photoURL, doc.role, doc.uID);

--- a/src/app/core/services/blog/blog.service.ts
+++ b/src/app/core/services/blog/blog.service.ts
@@ -56,7 +56,7 @@ export class BlogService {
 
     // Gets all docs from setted collection
     getDocs() {
-        getDocs(query(this.collection)).then(data => {
+        getDocs(query(this.collection, where("listed", "==", true))).then(data => {
             const ans: NewsItem[] = [];
             for (const blogEntry in data.docs) {
                 if (data.docs.hasOwnProperty(blogEntry)) {
@@ -90,6 +90,7 @@ export class BlogService {
         const call = new BehaviorSubject<NewsItem[]>([]);
         getDocs(query(this.collection, 
             where("date", "!=", Timestamp.fromDate(currentNewsDate)),
+            where("listed", "==", true),
             orderBy("date", "desc"),
             limit(10)
         )).then(snapshot => {
@@ -168,7 +169,7 @@ export class BlogService {
     }
 
     getNextDocsPage(tags?: string[]) {
-        let constraints: QueryConstraint[] = [orderBy('date', 'desc')];
+        let constraints: QueryConstraint[] = [orderBy('date', 'desc'), where("listed", "==", true)];
         if (tags && tags.length > 0) constraints.push(orderBy('tags'), where('tags', 'array-contains-any', tags));
         constraints.push(limit(this.docsPageSize), startAt(this.blogData.getValue().pop().date));
         const q = query(this.collection, ...constraints);
@@ -176,21 +177,21 @@ export class BlogService {
     }
 
     getPrevDocsPage(tags?: string[]) {
-        let constraints: QueryConstraint[] = [orderBy('date', 'desc')];
+        let constraints: QueryConstraint[] = [orderBy('date', 'desc'), where("listed", "==", true)];
         if (tags && tags.length > 0) constraints.push(orderBy('tags'), where('tags', 'array-contains-any', tags));
         constraints.push(limitToLast(this.docsPageSize), endAt(this.blogData.getValue().reverse().pop().date));
         const q = query(this.collection, ...constraints);
         this.getDocsPage(q);
     }
 
-  // Gets all docs from setted collection
-  getFirstDocsPage(cursor?: Date, tags?: string[]) {
-    let constraints: QueryConstraint[] = [orderBy('date', 'desc'), limit(this.docsPageSize)];
-    if (tags && tags.length > 0) constraints.push(orderBy('tags'), where('tags', 'array-contains-any', tags));
-    if (cursor) constraints.push(startAt(cursor));
-    const q = query(this.collection, ...constraints);
-    this.getDocsPage(q);
-  }
+    // Gets all docs from setted collection
+    getFirstDocsPage(cursor?: Date, tags?: string[]) {
+        let constraints: QueryConstraint[] = [orderBy('date', 'desc'), limit(this.docsPageSize), where("listed", "==", true)];
+        if (tags && tags.length > 0) constraints.push(orderBy('tags'), where('tags', 'array-contains-any', tags));
+        if (cursor) constraints.push(startAt(cursor));
+        const q = query(this.collection, ...constraints);
+        this.getDocsPage(q);
+    }
 
     // Sets a doc inside a collection and updates metadata
     setDoc(content: NewsItem) {

--- a/src/app/modules/admin/admin.module.ts
+++ b/src/app/modules/admin/admin.module.ts
@@ -1,0 +1,54 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AdminComponent } from './pages/admin/admin.component';
+import { MissingTranslationHandler, TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { HttpLoaderFactory } from 'src/app/shared/translation-helpers';
+import { HttpClient } from '@angular/common/http';
+import { CustomMissingTranslationHandler } from 'src/app/shared/CustomMissingTranslationHandler';
+import { RouterModule, Routes } from '@angular/router';
+import { SharedModule } from 'src/app/shared/shared.module';
+import {MatDividerModule} from '@angular/material/divider';
+import {MatListModule} from '@angular/material/list';
+import { MDBBootstrapModule } from 'angular-bootstrap-md';
+import { UsersComponent } from './pages/users/users.component';
+import { MatChipsModule } from '@angular/material/chips';
+import {MatPaginatorModule} from '@angular/material/paginator';
+
+// Tab manager
+const routes: Routes = [{ 
+  path: '', 
+  component: AdminComponent, 
+  children: [
+      { path: '', redirectTo: 'users', pathMatch: 'full' },
+      { path: 'users', component: UsersComponent }
+  ]
+}];
+
+export const routing = RouterModule.forChild(routes);
+
+@NgModule({
+  declarations: [
+    AdminComponent,
+    UsersComponent
+  ],
+  imports: [
+    routing,
+    CommonModule,
+    SharedModule,
+    MatDividerModule,
+    MatListModule,
+    MatChipsModule,
+    MatPaginatorModule,
+    MDBBootstrapModule.forRoot(),
+    TranslateModule.forChild({
+      loader: {
+          provide: TranslateLoader,
+          useFactory: HttpLoaderFactory,
+          deps: [HttpClient],
+      },
+      missingTranslationHandler: {provide: MissingTranslationHandler, useClass: CustomMissingTranslationHandler},
+      extend: true
+  }),
+  ]
+})
+export class AdminModule { }

--- a/src/app/modules/admin/pages/admin/admin.component.css
+++ b/src/app/modules/admin/pages/admin/admin.component.css
@@ -38,3 +38,23 @@ aside {
 a.selected {
     background-color: #DEDEDE;
 }
+
+@media (max-width: 860px){
+    .wrapper {
+        grid-template-areas: 
+            "sidebar"
+            "content";
+        grid-template-columns: 1fr;
+    }
+
+    .content {
+        border-left: none;
+        margin-left: 0;
+    }
+}
+
+@media (max-width: 550px) {
+    .main-container {
+        padding: 10rem .2rem 0 .2rem;
+    }
+}

--- a/src/app/modules/admin/pages/admin/admin.component.css
+++ b/src/app/modules/admin/pages/admin/admin.component.css
@@ -1,0 +1,40 @@
+.title-container {
+    text-align: center;
+}
+  
+.page-title {
+    color: var(--bs-ieee-bright-blue);
+    font-size: 2.5em;
+    margin: 0.25em;
+}
+
+.grid {
+    display: grid;
+}
+
+aside {
+    grid-area: sidebar;
+    padding: 1rem;
+}
+
+.content {
+    grid-area: content;
+    padding: 1rem;
+    margin-left: 1rem;
+    border-left: 1px solid #DEDEDE;
+}
+
+.wrapper {
+    display: grid;
+    margin-top: 2rem;
+    grid-template-columns: 1fr 3fr;
+    grid-template-areas: "sidebar content";
+}
+
+.tab-icon {
+    margin-right: .2rem;
+}
+
+a.selected {
+    background-color: #DEDEDE;
+}

--- a/src/app/modules/admin/pages/admin/admin.component.html
+++ b/src/app/modules/admin/pages/admin/admin.component.html
@@ -1,0 +1,21 @@
+<div class="main-container">
+    <div class="title-container">
+        <h1 class="page-title">{{ "ADMIN.TITLE" | translate }}</h1>
+    </div>
+    <div class="wrapper">
+        <aside>
+            <mat-nav-list>
+                <div>
+                    <a mat-list-item *ngFor="let tab of tabs" [class]="tab.selected ? 'selected' : ''" [activated]="tab.isActive" [routerLink]="[tab.link]" routerLinkActive="router-link-active" >
+                        <mdb-icon fas [icon]="tab.icon" class="tab-icon" mdbWavesEffect />
+                        {{ tab.title | translate }}
+                    </a>
+                    <mat-divider />
+                </div>
+            </mat-nav-list>
+        </aside>
+        <div class="content">
+            <router-outlet></router-outlet>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/admin/pages/admin/admin.component.html
+++ b/src/app/modules/admin/pages/admin/admin.component.html
@@ -6,7 +6,12 @@
         <aside>
             <mat-nav-list>
                 <div>
-                    <a mat-list-item *ngFor="let tab of tabs" [class]="tab.selected ? 'selected' : ''" [activated]="tab.isActive" [routerLink]="[tab.link]" routerLinkActive="router-link-active" >
+                    <a mat-list-item 
+                    *ngFor="let tab of tabs" 
+                    [class.selected]="url.split('/')[2] == tab.link" 
+                    [activated]="tab.isActive" 
+                    [routerLink]="[tab.link]" 
+                    routerLinkActive="router-link-active">
                         <mdb-icon fas [icon]="tab.icon" class="tab-icon" mdbWavesEffect />
                         {{ tab.title | translate }}
                     </a>

--- a/src/app/modules/admin/pages/admin/admin.component.spec.ts
+++ b/src/app/modules/admin/pages/admin/admin.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminComponent } from './admin.component';
+
+describe('AdminComponent', () => {
+  let component: AdminComponent;
+  let fixture: ComponentFixture<AdminComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [AdminComponent]
+    });
+    fixture = TestBed.createComponent(AdminComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/admin/pages/admin/admin.component.ts
+++ b/src/app/modules/admin/pages/admin/admin.component.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-admin',
+  templateUrl: './admin.component.html',
+  styleUrls: ['./admin.component.css']
+})
+export class AdminComponent {
+
+  tabs = [
+    {
+      title: "ADMIN.USERTAB",
+      link: "users",
+      isActive: true,
+      icon: "user",
+      selected: this.router.url.split("/")[1] == "users"
+    }
+  ]
+
+  constructor(private router: Router) {}
+}

--- a/src/app/modules/admin/pages/admin/admin.component.ts
+++ b/src/app/modules/admin/pages/admin/admin.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 @Component({
@@ -6,17 +6,23 @@ import { Router } from '@angular/router';
   templateUrl: './admin.component.html',
   styleUrls: ['./admin.component.css']
 })
-export class AdminComponent {
+export class AdminComponent implements OnInit {
+
+  url: string
 
   tabs = [
     {
-      title: "ADMIN.USERTAB",
+      title: "ADMIN.USERTAB.TITLE",
       link: "users",
       isActive: true,
       icon: "user",
-      selected: this.router.url.split("/")[1] == "users"
     }
   ]
 
   constructor(private router: Router) {}
+
+  ngOnInit(): void {
+    this.url = this.router.url;
+  }
+
 }

--- a/src/app/modules/admin/pages/users/user.manager.spec.ts
+++ b/src/app/modules/admin/pages/users/user.manager.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UserManagerService } from './user.manager';
+
+describe('UserManagerService', () => {
+  let service: UserManagerService;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UserManagerService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/modules/admin/pages/users/user.manager.ts
+++ b/src/app/modules/admin/pages/users/user.manager.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, combineLatest, distinctUntilChanged, map } from 'rxjs';
+import { AdminService } from 'src/app/core/services/admin/admin.service';
+import { IEEEuser } from 'src/app/shared/models/ieee-user/ieee-user';
+import { IEEEUserFilters } from 'src/app/shared/models/ieee-user/ieee-user-filters';
+
+@Injectable()
+export class UserManagerService {
+  private users$ = new BehaviorSubject<IEEEuser[]>([]);
+  private userCount$ = new BehaviorSubject<number>(0);
+  
+  private startCursor$ = new BehaviorSubject<IEEEuser | null>(null);
+  private endCursor$ = new BehaviorSubject<IEEEuser | null>(null);
+  private filters$ = new BehaviorSubject<IEEEUserFilters | null>(null);
+
+  private userPage$: BehaviorSubject<number> = new BehaviorSubject<number>(1);
+  private userPageSize$: BehaviorSubject<number> = new BehaviorSubject<number>(10);
+
+  private loading$ = new BehaviorSubject<boolean>(false);
+
+  constructor(private readonly adminService: AdminService) {
+    adminService.setCollectionName('users');
+  }
+
+  public pullUsers() {
+    const filters = this.filters$.getValue();
+    this.loading$.next(false);
+    this.adminService.getUsersFirstPage(this.userPageSize$.getValue(), filters)
+      .subscribe((users) => {
+        this.users$.next(users);
+        this.setCursors(users);
+        this.pullUserCount();
+        this.userPage$.next(1);
+        this.loading$.next(true);
+      });
+  }
+
+  private pullUserCount() {
+    const filters = this.filters$.getValue();
+    this.adminService.getTotalCount(filters).subscribe(count => {
+      this.userCount$.next(count);
+    })
+  }
+  
+  public applyFilters(filters?: IEEEUserFilters) {
+    this.filters$.next(filters || null);
+    this.pullUsers();
+  }
+
+  private hasNextPage(): boolean {
+    const userCount = this.userCount$.getValue();
+    const endCursor = this.endCursor$.getValue();
+    let pageCount = Math.floor((userCount - 1) / this.userPageSize$.getValue()) + 1;
+    return this.userPage$.getValue() < pageCount || !endCursor;
+  }
+
+  private hasPrevPage(): boolean {
+    const startCursor = this.startCursor$.getValue();
+    return this.userPage$.getValue() >= 1 || !startCursor;
+  }
+
+  public pullNextPage() {
+    if (!this.hasNextPage()) return;
+    const endCursor = this.endCursor$.getValue();
+    const pageSize = this.userPageSize$.getValue();
+    const filters = this.filters$.getValue();
+    this.loading$.next(true);
+    this.adminService.getUsersNextPage(endCursor, pageSize, filters).subscribe(users => {
+      let page = this.userPageSize$.getValue();
+      this.users$.next(users);
+      this.setCursors(users);
+      this.userPageSize$.next(page++);
+      this.loading$.next(false);
+    });
+  }
+
+  public pullPrevPage() {
+    if (!this.hasPrevPage()) return;
+    const startCursor = this.startCursor$.getValue();
+    const pageSize = this.userPageSize$.getValue();
+    const filters = this.filters$.getValue();
+    this.loading$.next(true);
+    this.adminService.getUsersPrevPage(startCursor, pageSize, filters).subscribe(users => {
+      let page = this.userPageSize$.getValue();
+      this.users$.next(users);
+      this.setCursors(users);
+      this.userPageSize$.next(page--);
+      this.loading$.next(false);
+    });
+  }
+
+  public setPageSize(size: number): boolean {
+    if (size == this.userPageSize$.getValue()) return false;
+    this.userPage$.next(1);
+    this.userPageSize$.next(size);
+    this.pullUsers();
+    return true;
+  }
+
+  public getUsers(): Observable<{ content: IEEEuser[], count: number, loading: boolean }> {
+    return combineLatest([this.users$, this.userCount$, this.loading$]).pipe(
+      map(([users, count, loading]) => ({ content: users, count, loading })),
+      distinctUntilChanged()
+    );
+  }
+
+  public updateUserLocally(user: IEEEuser) {
+    let users = this.users$.getValue();
+    let userIndex = users.findIndex(u => u.email == user.email);
+    if (userIndex < 0) return;
+    users[userIndex] = user;
+    this.users$.next(users);
+  }
+
+  public getUserPage(): Observable<{ page: number, size: number }> {
+    return combineLatest([this.userPage$, this.userPageSize$]).pipe(map(([page, size]) => ({ page, size })));
+  }
+
+  private setCursors(users: IEEEuser[]) {
+    if (users.length > 0) {
+      this.startCursor$.next(users[0]);
+      this.endCursor$.next(users[users.length - 1]);
+    }
+    else {
+      this.startCursor$.next(null);
+      this.endCursor$.next(null);
+    }
+  }
+}

--- a/src/app/modules/admin/pages/users/users.component.css
+++ b/src/app/modules/admin/pages/users/users.component.css
@@ -32,6 +32,7 @@
 table {
     width: 100%;
     margin-top: .25rem;
+    table-layout: fixed;
 }
 
 tr {
@@ -40,11 +41,17 @@ tr {
 
 th, td {
     padding: 0 1rem;
+    overflow: hidden;
 }
 
 tr:not(:first-child):hover {
     background-color: #DEDEDE;
     cursor: pointer
+}
+
+.role-col {
+    vertical-align: middle;
+    text-align: center;
 }
 
 .small-chip {
@@ -62,4 +69,14 @@ p.role-filter-label {
 
 .role-filter {
     padding: 0 1rem;
+}
+
+@media (max-width: 550px) {
+    .search-bar {
+        width: 100%;
+    }
+
+    th, td {
+        padding: 0;
+    }
 }

--- a/src/app/modules/admin/pages/users/users.component.css
+++ b/src/app/modules/admin/pages/users/users.component.css
@@ -31,7 +31,7 @@
 
 table {
     width: 100%;
-    margin-top: 1rem;
+    margin-top: .25rem;
 }
 
 tr {
@@ -44,6 +44,7 @@ th, td {
 
 tr:not(:first-child):hover {
     background-color: #DEDEDE;
+    cursor: pointer
 }
 
 .small-chip {
@@ -52,4 +53,13 @@ tr:not(:first-child):hover {
 
 .paginator {
     margin-top: 2rem;
+}
+
+p.role-filter-label {
+    margin-bottom: .2rem;
+    margin-top: .5rem;
+}
+
+.role-filter {
+    padding: 0 1rem;
 }

--- a/src/app/modules/admin/pages/users/users.component.css
+++ b/src/app/modules/admin/pages/users/users.component.css
@@ -1,0 +1,55 @@
+.search-bar {
+    margin: 0 auto;
+    width: 70%;
+    height: 3rem;
+    background-color: #DEDEDE;
+    border-radius: 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: .5rem 1rem;
+}
+
+.search-bar .search-icon {
+    color:gray;
+    height: 80%;
+    display: flex;
+    align-items: center;
+}
+
+.search-bar input#user {
+    width: 100%;
+    height: 100%;
+    margin: 0 1rem;
+    background: none;
+    border: none;
+}
+
+.search-bar input#user:focus {
+    outline: none;
+}
+
+table {
+    width: 100%;
+    margin-top: 1rem;
+}
+
+tr {
+    height: 2rem;
+}
+
+th, td {
+    padding: 0 1rem;
+}
+
+tr:not(:first-child):hover {
+    background-color: #DEDEDE;
+}
+
+.small-chip {
+    height: 20px !important;
+}
+
+.paginator {
+    margin-top: 2rem;
+}

--- a/src/app/modules/admin/pages/users/users.component.html
+++ b/src/app/modules/admin/pages/users/users.component.html
@@ -1,28 +1,42 @@
 <div class="search-bar">
     <mdb-icon fas icon="search" class="search-icon" mdbWavesEffect />
-    <input (keyup)="handleInputEvent($event)" (submit)="handleInputEvent($event)" type="text" name="user" id="user" autocomplete="off" placeholder="Buscar usuario por email">
+    <input (keyup)="handleSearchbarEvent($event)" 
+        (submit)="handleSearchbarEvent($event)" 
+        type="text" name="user" id="user" 
+        autocomplete="off" 
+        [placeholder]=" 'ADMIN.USERTAB.SEARCHBAR' | translate ">
     <mdb-icon fas icon="chevron-right" class="search-icon" mdbWavesEffect />
 </div>
+<p class="role-filter-label">Filtrar por roles:</p>
+<mat-chip-listbox class="role-filter" aria-label="Role filter" (change)="handleRoleFilterEvent($event)" id="role" multiple>
+    <mat-chip-option *ngFor="let role of roles | slice:1; index as i" 
+        [color]="role.color" 
+        [value]="i+1">
+        {{ role.code | translate }}
+    </mat-chip-option>
+</mat-chip-listbox>
 <table>
     <tr>
-        <th>Nombre</th>
-        <th>Apellido</th>
-        <th>Email</th>
-        <th>Rol</th>
+        <th>{{ "ADMIN.USERTAB.TABLE.FNAME" | translate }}</th>
+        <th>{{ "ADMIN.USERTAB.TABLE.LNAME" | translate }}</th>
+        <th>{{ "ADMIN.USERTAB.TABLE.EMAIL" | translate }}</th>
+        <th>{{ "ADMIN.USERTAB.TABLE.ROLE" | translate }}</th>
     </tr>
-    <tr *ngFor="let user of users$ | async">
+    <tr *ngFor="let user of (users$ | async).content" (click)="openModal(user)">
         <td>{{ user.fname }}</td>
         <td>{{ user.lname }}</td>
         <td>{{ user.email }}</td>
         <td>
-            <mat-chip class="small-chip" *ngIf="roles[user.role]" [color]="colors[user.role]" highlighted>{{ roles[user.role] }}</mat-chip>
+            <mat-chip class="small-chip" *ngIf="roles[user.role]" [color]="roles[user.role].color" highlighted>{{ roles[user.role].code | translate }}</mat-chip>
         </td>
     </tr>
 </table>
-<mat-paginator [length]="count"
-              [pageSize]="10"
-              [pageSizeOptions]="[5, 10, 25, 100]"
-              (page)="handlePageEvent($event)"
-              aria-label="Select page"
-              class="paginator">
+<mat-paginator 
+    #paginator
+    [length]="(users$ | async).count"
+    [pageSize]="10"
+    [pageSizeOptions]="[10, 25, 50, 100]"
+    (page)="handlePageEvent($event)"
+    aria-label="Select page"
+    class="paginator">
 </mat-paginator>

--- a/src/app/modules/admin/pages/users/users.component.html
+++ b/src/app/modules/admin/pages/users/users.component.html
@@ -26,7 +26,7 @@
         <td>{{ user.fname }}</td>
         <td>{{ user.lname }}</td>
         <td>{{ user.email }}</td>
-        <td>
+        <td class="role-col">
             <mat-chip class="small-chip" *ngIf="roles[user.role]" [color]="roles[user.role].color" highlighted>{{ roles[user.role].code | translate }}</mat-chip>
         </td>
     </tr>

--- a/src/app/modules/admin/pages/users/users.component.html
+++ b/src/app/modules/admin/pages/users/users.component.html
@@ -1,0 +1,28 @@
+<div class="search-bar">
+    <mdb-icon fas icon="search" class="search-icon" mdbWavesEffect />
+    <input (keyup)="handleInputEvent($event)" (submit)="handleInputEvent($event)" type="text" name="user" id="user" autocomplete="off" placeholder="Buscar usuario por email">
+    <mdb-icon fas icon="chevron-right" class="search-icon" mdbWavesEffect />
+</div>
+<table>
+    <tr>
+        <th>Nombre</th>
+        <th>Apellido</th>
+        <th>Email</th>
+        <th>Rol</th>
+    </tr>
+    <tr *ngFor="let user of users$ | async">
+        <td>{{ user.fname }}</td>
+        <td>{{ user.lname }}</td>
+        <td>{{ user.email }}</td>
+        <td>
+            <mat-chip class="small-chip" *ngIf="roles[user.role]" [color]="colors[user.role]" highlighted>{{ roles[user.role] }}</mat-chip>
+        </td>
+    </tr>
+</table>
+<mat-paginator [length]="count"
+              [pageSize]="10"
+              [pageSizeOptions]="[5, 10, 25, 100]"
+              (page)="handlePageEvent($event)"
+              aria-label="Select page"
+              class="paginator">
+</mat-paginator>

--- a/src/app/modules/admin/pages/users/users.component.spec.ts
+++ b/src/app/modules/admin/pages/users/users.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UsersComponent } from './users.component';
+
+describe('UsersComponent', () => {
+  let component: UsersComponent;
+  let fixture: ComponentFixture<UsersComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [UsersComponent]
+    });
+    fixture = TestBed.createComponent(UsersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/admin/pages/users/users.component.ts
+++ b/src/app/modules/admin/pages/users/users.component.ts
@@ -1,0 +1,104 @@
+import { Component, OnInit } from '@angular/core';
+import { AdminService } from "../../../../core/services/admin/admin.service"
+import { BehaviorSubject, Observable, combineLatest, last, map, switchMap } from 'rxjs';
+import { IEEEuser } from 'src/app/shared/models/ieee-user/ieee-user';
+import { PageEvent } from '@angular/material/paginator';
+
+@Component({
+  selector: 'app-users',
+  templateUrl: './users.component.html',
+  styleUrls: ['./users.component.css']
+})
+export class UsersComponent implements OnInit {
+
+  users$: Observable<IEEEuser[]>;
+  count: number;
+  cursor: IEEEuser[] = [];
+
+  searchbarTimeout: number;
+  searchword$: BehaviorSubject<string> = new BehaviorSubject(null);
+
+  roles: string[] = [null, "Admin", "Escritor"]
+  colors: string[] = [null, "primary", "accent"]
+
+  userPage$: BehaviorSubject<number> = new BehaviorSubject<number>(1);
+  userPageSize$: BehaviorSubject<number> = new BehaviorSubject<number>(10);
+  
+  constructor(private adminService: AdminService) {
+    adminService.setCollectionName('users');
+  }
+
+  setPageSize(size: number) {
+    this.userPage$.next(1);
+    this.userPageSize$.next(size);
+    this.firstPage();
+  }
+
+  hasNextPage(): boolean {
+    let pageCount = Math.floor((this.count - 1) / this.userPageSize$.getValue()) + 1;
+    return this.userPage$.getValue() < pageCount || !this.cursor[1];
+  }
+
+  hasPrevPage(): boolean {
+    return this.userPage$.getValue() > 1 || !this.cursor[0];
+  }
+  
+  nextPage() {
+    if (!this.hasNextPage()) return;
+    this.users$ = this.adminService.getUsersNextPage(this.cursor[1], this.userPageSize$.getValue(), this.searchword$.getValue());
+    this.setCursor();
+    this.userPage$.next(this.userPage$.getValue() + 1);
+  }
+
+  prevPage() {
+    if (!this.hasPrevPage()) return;
+    this.users$ = this.adminService.getUsersPrevPage(this.cursor[0], this.userPageSize$.getValue(), this.searchword$.getValue());
+    this.setCursor();
+    this.userPage$.next(this.userPage$.getValue() - 1);
+  }
+
+  firstPage() {
+    this.users$ = this.adminService.getUsersFirstPage(this.userPageSize$.getValue(), this.searchword$.getValue());
+    this.setCursor();
+  }
+
+  setCursor() {
+    this.users$.subscribe((users) => {
+      this.cursor[0] = users[0];
+      this.cursor[1] = users[users.length - 1];
+    })
+  }
+
+  handlePageEvent(e: PageEvent) {
+    if (e.pageIndex > e.previousPageIndex) this.nextPage();
+    if (e.pageIndex < e.previousPageIndex) this.prevPage();
+    if (e.pageSize != this.userPageSize$.getValue()) this.setPageSize(e.pageSize);
+  }
+
+  handleInputEvent(e: any) {
+    if (this.searchbarTimeout) clearTimeout(this.searchbarTimeout);
+    this.searchbarTimeout = setTimeout(() => {
+      if (e.target.value == this.searchword$.getValue()) return;
+      if (e.target.value.trim() == "") this.searchword$.next(null);
+      else this.searchword$.next(e.target.value);
+      this.userPage$.next(1);
+      this.firstPage();
+      this.getCount();
+    }, 1000);
+  }
+
+  getCount() {
+    let count$: Observable<number>;
+    if (!this.searchword$.getValue()) count$ = this.adminService.getTotalCount();
+    else count$ = this.adminService.getSearchCount(this.searchword$.getValue());
+    count$.subscribe(count => {
+      this.count = count;
+    })
+  }
+
+  ngOnInit(): void {
+    this.firstPage();
+    this.getCount();
+  }
+
+}

--- a/src/app/shared/components/navbar/navbar.component.html
+++ b/src/app/shared/components/navbar/navbar.component.html
@@ -82,7 +82,8 @@
 
           <div class="dropdown-menu dropdown-menu-right dropdown-primary">
               <ng-container *ngIf="user$ | async; else noUser">
-                  <a class="dropdown-item"  (click)="logoutUser()">{{ 'LOGOUT.TITLE' | translate }}</a>
+                <a class="dropdown-item" *ngIf="isAdmin$ | async"  [routerLink]="['/admin']">{{ 'NAVBAR.ADMIN' | translate }}</a>
+                <a class="dropdown-item"  (click)="logoutUser()">{{ 'LOGOUT.TITLE' | translate }}</a>
               </ng-container>
             <ng-template #noUser>
                 <a class="dropdown-item" [routerLink]="['/login']">{{ 'LOGIN.TITLE' | translate }}</a>

--- a/src/app/shared/components/navbar/navbar.component.ts
+++ b/src/app/shared/components/navbar/navbar.component.ts
@@ -19,6 +19,7 @@ export class NavbarComponent implements OnInit, AfterViewInit{
 
   user$ = new BehaviorSubject<IEEEuser | null>(null);
   isJournalist$ = new BehaviorSubject<boolean>(false);
+  isAdmin$ = new BehaviorSubject<boolean>(false);
   language: string;
   color: string;
   isLoading: boolean = true;
@@ -51,9 +52,8 @@ export class NavbarComponent implements OnInit, AfterViewInit{
       this.authService.getCurrentUser().subscribe(async (usuario: IEEEuser) => {
           if (usuario) {
               const aux: number = usuario.role || await this.userService.getCurrentUserRole(usuario.email);
-              if (this.newsRoles.includes(aux)) {
-                  this.isJournalist$.next(true);
-              }
+              if (this.newsRoles.includes(aux)) this.isJournalist$.next(true);
+              if (aux == roles.admin) this.isAdmin$.next(true);
               this.user$.next(usuario);
           }
           this.isLoading = false;

--- a/src/app/shared/components/user-editor-modal/user-editor-modal.component.css
+++ b/src/app/shared/components/user-editor-modal/user-editor-modal.component.css
@@ -1,0 +1,65 @@
+.modal-header {
+    align-items: flex-start;
+}
+
+.modal-title span {
+    font-weight: 600;
+}
+
+.modal-title, .modal-subtitle {
+    margin-bottom: 0;
+}
+
+.modal-body label {
+    font-weight: 600;
+    font-size: 1rem;
+}
+
+.modal-body .error-container {
+    margin-top: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    row-gap: 0.25rem;
+}
+
+.modal-body p.error {
+    color: var(--bs-danger);
+    font-weight: 600;
+    font-size: 0.9rem;
+    margin-bottom: 0;
+}
+
+.modal-footer button {
+    border-radius: 12px;
+    padding: 0.5rem 1rem;
+    font-weight: 600;
+    font-size: 0.9rem;
+    transition: box-shadow 0.2s ease-in-out;
+}
+
+.modal-footer, .modal-header {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
+.modal-footer .close-btn {
+    background-color: var(--bs-light);
+    color: var(--bs-ieee-bright-blue);
+    border-color: var(--bs-ieee-bright-blue);
+    box-shadow: 0 0 4px var(--bs-ieee-bright-blue);
+}
+
+.modal-footer .close-btn:hover {
+    box-shadow: 0 0 2px var(--bs-ieee-bright-blue);
+}
+
+.modal-footer .save-btn {
+    background-color: var(--bs-ieee-bright-blue);
+    color: var(--bs-light);
+    border-color: var(--bs-ieee-bright-blue);
+    box-shadow: 0 0 4px var(--bs-ieee-bright-blue);
+}
+
+.modal-footer .save-btn:hover {
+    box-shadow: 0 0 2px var(--bs-ieee-bright-blue);
+}

--- a/src/app/shared/components/user-editor-modal/user-editor-modal.component.html
+++ b/src/app/shared/components/user-editor-modal/user-editor-modal.component.html
@@ -1,0 +1,33 @@
+<div class="modal-header">
+    <div>
+        <h2 class="modal-title"><span>{{ user.fname }} {{ user.lname }}</span></h2>
+        <h4 class="modal-subtitle">{{ user.email }}</h4>
+    </div>
+    <button type="button" (click)="modalRef.hide()" class="btn">
+        <mdb-icon fas icon="times" size="lg"></mdb-icon>
+    </button>
+</div>
+<form>
+    <div class="modal-body">
+        <label for="role">{{ "ADMIN.USERTAB.TABLE.ROLE" | translate }}</label>
+        <mat-chip-listbox aria-label="Role selection" (change)="changeRole($event)" id="role">
+            <mat-chip-option *ngFor="let role of roles | slice:1; index as i" 
+                [color]="role.color" 
+                [selected]="user.role == i+1"
+                [value]="i+1">
+                {{ role.code | translate }}
+            </mat-chip-option>
+        </mat-chip-listbox>
+        <div *ngIf="error" class="error-container">
+            <p class="error">
+                {{ error | translate }}
+            </p>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn close-btn" (click)="modalRef.hide()">{{ "HOME.EVENTS.EDIT.CANCEL" | translate }}</button>
+        <button type="submit" class="btn save-btn" (click)="updateUser()">
+            {{ "HOME.EVENTS.EDIT.UPDATE" | translate }}
+        </button>
+    </div>
+</form>

--- a/src/app/shared/components/user-editor-modal/user-editor-modal.component.spec.ts
+++ b/src/app/shared/components/user-editor-modal/user-editor-modal.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserEditorModalComponent } from './user-editor-modal.component';
+
+describe('UserEditorModalComponent', () => {
+  let component: UserEditorModalComponent;
+  let fixture: ComponentFixture<UserEditorModalComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [UserEditorModalComponent]
+    });
+    fixture = TestBed.createComponent(UserEditorModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/user-editor-modal/user-editor-modal.component.ts
+++ b/src/app/shared/components/user-editor-modal/user-editor-modal.component.ts
@@ -1,0 +1,42 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { IEEEuser } from '../../models/ieee-user/ieee-user';
+import { AdminService } from 'src/app/core/services/admin/admin.service';
+import { MDBModalRef } from 'angular-bootstrap-md';
+import { roles } from '../../models/roles/roles';
+import { MatChipListboxChange } from '@angular/material/chips';
+
+@Component({
+  selector: 'app-user-editor-modal',
+  templateUrl: './user-editor-modal.component.html',
+  styleUrls: ['./user-editor-modal.component.css']
+})
+export class UserEditorModalComponent {
+    
+    @Input() user: IEEEuser;
+    @Output() update: EventEmitter<IEEEuser> = new EventEmitter();
+    updatedUser: IEEEuser;
+    roles = roles;
+
+    error: string;
+
+    constructor(private adminService: AdminService, public modalRef: MDBModalRef) { }
+
+    ngOnInit(): void {
+        this.updatedUser = { ...this.user };
+    }
+
+    changeRole(e: MatChipListboxChange) {
+      this.updatedUser.role = e.value | 0;
+    }
+
+    updateUser() {
+      if (JSON.stringify(this.updatedUser) == JSON.stringify(this.user)) return this.error = "ADMIN.USERTAB.ERRORS.NO_CHANGES";
+      if (this.updatedUser.email != this.user.email) return this.error = "ADMIN.USERTAB.ERRORS.CANNOT_CHANGE_EMAIL";
+      this.adminService.updateUser(this.updatedUser, this.updatedUser.role != this.user.role).subscribe(res => {
+        delete this.error;
+        this.update.emit(this.updatedUser);
+        this.modalRef.hide();
+      });
+      
+    }
+}

--- a/src/app/shared/models/ieee-user/ieee-user-filters.ts
+++ b/src/app/shared/models/ieee-user/ieee-user-filters.ts
@@ -1,0 +1,5 @@
+
+export interface IEEEUserFilters {
+    email?: string
+    role?: number[]
+}

--- a/src/app/shared/models/roles/roles.ts
+++ b/src/app/shared/models/roles/roles.ts
@@ -1,0 +1,16 @@
+export interface Role {
+    code: string;
+    color: string;
+}
+
+export const roles: (Role | null)[] = [
+    null,
+    {
+        code: "ADMIN.USERTAB.ROLES.ADMIN",
+        color: "primary"
+    },
+    {
+        code: "ADMIN.USERTAB.ROLES.WRITER",
+        color: "accent"
+    }
+]

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -40,6 +40,7 @@ import {EventEditorModalComponent} from "./components/event-editor-modal/event-e
 import { EventEditorButtonComponent } from './components/event-editor-button/event-editor-button.component';
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import { FloatingButtonComponent } from './components/floating-button/floating-button.component';
+import { UserEditorModalComponent } from './components/user-editor-modal/user-editor-modal.component';
 
 // TODO: Modify this, ContactPageComponent does not belong here!
 const routes: Routes = [];
@@ -52,7 +53,7 @@ export const routing = RouterModule.forChild(routes);
         TeamCardComponent, EventCardShortComponent, StudentChapterComponent, PaginationComponent,
         EventTitleComponent, EventBannerComponent, EventContentCardComponent, EventFaqAccordionComponent,
         EventSectionComponent, ImageCarouselComponent, EventFactsBannerComponent, ButtonComponent,
-        EventEditorModalComponent, EventEditorButtonComponent, FloatingButtonComponent],
+        EventEditorModalComponent, EventEditorButtonComponent, FloatingButtonComponent, UserEditorModalComponent],
     imports: [
         routing,
         CommonModule,

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,9 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import {NavbarComponent} from './components/navbar/navbar.component';
-import {MatFormFieldModule} from '@angular/material/form-field';
-import {MatInputModule} from '@angular/material/input';
-import {MatGridListModule} from '@angular/material/grid-list';
 import {FooterComponent} from './components/footer/footer.component';
 import {MissingTranslationHandler, TranslateLoader, TranslateModule} from '@ngx-translate/core';
 import {HttpClient} from '@angular/common/http';
@@ -11,7 +8,6 @@ import {FlexLayoutModule} from '@angular/flex-layout';
 import {MDBBootstrapModule} from 'angular-bootstrap-md';
 import {MatMenuModule} from '@angular/material/menu';
 import {RouterModule, Routes} from '@angular/router';
-import {ContactPageComponent} from '../modules/contact/pages/contact/contact-page.component';
 import {LoadingSpinnerComponent} from './components/loading-spinner/loading-spinner.component';
 import {Error401Component} from './components/error401/error401.component';
 import {MatButtonToggleModule} from '@angular/material/button-toggle';

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -987,6 +987,23 @@
   },
   "ADMIN": {
     "TITLE": "Admin panel",
-    "USERTAB": "Users"
+    "USERTAB": {
+      "TITLE": "Users",
+      "TABLE": {
+        "FNAME": "First Name",
+        "LNAME": "Last Name",
+        "EMAIL": "Email",
+        "ROLE": "Role"
+      },
+      "SEARCHBAR": "Search user by email",
+      "ERRORS": {
+        "NO_CHANGES": "There are no changes to save",
+        "CANNOT_CHANGE_EMAIL": "It is not possible to change the user's email"
+      },
+      "ROLES": {
+        "ADMIN": "Admin",
+        "WRITER": "Writer"
+      }
+    }
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -326,7 +326,8 @@
     "NEWS": "News",
     "SPONSORS": "Sponsors",
     "WRITENEWS": "Create News",
-    "INSTITUTIONAL": "Institutional"
+    "INSTITUTIONAL": "Institutional",
+    "ADMIN": "Admin panel"
   },
     "FOOTER": {
         "ABOUTUS": "About us",
@@ -971,5 +972,9 @@
   },
   "CS": {
     "ABOUT": "A technology-focused organization made up of students and alumni of ITBA, dedicated to inspiring and educating in various areas of technology related to software engineering and technology."
+  },
+  "ADMIN": {
+    "TITLE": "Admin panel",
+    "USERTAB": "Users"
   }
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1039,7 +1039,24 @@
     "ABOUT": "Organización enfocada en la tecnología conformada por estudiantes y ex alumnos del ITBA, dedicada a inspirar y educar en diversas áreas de la tecnología relacionadas con la ingeniería y la tecnología de software."
   },
   "ADMIN": {
-    "TITLE": "Panel de administración",
-    "USERTAB": "Usuarios"
+    "TITLE": "Admin panel",
+    "USERTAB": {
+      "TITLE": "Usuarios",
+      "TABLE": {
+        "FNAME": "Nombre",
+        "LNAME": "Apellido",
+        "EMAIL": "Email",
+        "ROLE": "Rol"
+      },
+      "SEARCHBAR": "Buscar usuario por email",
+      "ERRORS": {
+        "NO_CHANGES": "No hay cambios para guardar",
+        "CANNOT_CHANGE_EMAIL": "No es posible modificar el email del usuario"
+      },
+      "ROLES": {
+        "ADMIN": "Admin",
+        "WRITER": "Escritor"
+      }
+    }
   }
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -382,7 +382,8 @@
     "NEWS": "Noticias",
     "SPONSORS": "Auspiciantes",
     "WRITENEWS": "Crear Noticia",
-    "INSTITUTIONAL": "Institucional"
+    "INSTITUTIONAL": "Institucional",
+    "ADMIN": "Panel de administrador"
   },
     "FOOTER": {
         "ABOUTUS": "Acerca de",
@@ -1024,5 +1025,9 @@
   },
   "CS": {
     "ABOUT": "Organización enfocada en la tecnología conformada por estudiantes y ex alumnos del ITBA, dedicada a inspirar y educar en diversas áreas de la tecnología relacionadas con la ingeniería y la tecnología de software."
+  },
+  "ADMIN": {
+    "TITLE": "Panel de administración",
+    "USERTAB": "Usuarios"
   }
 }


### PR DESCRIPTION
Se actualizaron las reglas de Firestore, permitiendo el acceso a la base de datos según el rol del usuario.
Se agregó el apartado "Panel de administración" que le permite a los administradores gestionar a los usuarios y modificar los roles de cada uno (Por ahora se permite un solo rol por usuario).
**Importante antes de mergear:**
- Ejecutar la script "migrate-sensitive-user-data.ts" para migrar los roles en producción.
- Cambiar las reglas de Firestore por las nuevas (ubicadas en "./firestore.rules"). Se puede subir directamente usando el Firebase CLI e incluso ejecutarlo en las GitHub Actions para mayor practicidad en futuros cambios de las reglas.